### PR TITLE
Change wording

### DIFF
--- a/contributing/communications.md
+++ b/contributing/communications.md
@@ -111,7 +111,7 @@ Now that you have at least one other core team member in the loop, you should di
 
 ### Resolution
 
-When you've come to a decision on whether the reported behavior violates the Code of Conduct, you'll need to decide on a resolution. Regardless of what action you take, the reporter should **never** be identified to their harasser. Possible resolutions include:
+When you've come to a decision on whether the reported behavior violates the Code of Conduct, you'll need to decide on a resolution. Regardless of what action you take, the reporter should **never** be identified to the individual who is being reported. Possible resolutions include:
 
   - Taking no further action (if it's determined that no violation occurred).
 


### PR DESCRIPTION
Suggest changing this wording as it's possible that an individual may fall foul of the code of conduct without specifically harassing another individual - e.g. persistent rudeness/unhelpfulness towards everybody, inappropriate tone in general, &c. 

To effectively enforce code of conduct we need to make sure that people don't try to weasel out of a telling-off by arguing with stuff like, "well I didn't ACTUALLY HARASS ANYONE, DID I" even though their behaviour is otherwise egregious or invidious. 