### PR TITLE
Add a news page, feed, and two starter posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Editing this site
 
 The home page text content can be found in [`pages/home.md`](pages/home.md).
 
+### News feed
+
+The news feed content can be found in the [`_posts` folder](_posts). It's best to copy an existing item and change the date/title.
+
+It's important to note that the date appears in both the file name and the `date` front-matter property.
+
 ### Projects page
 
 The projects page text content can be found in [`pages/projects.md`](pages/projects.md). The actual project list is automatically generated from the organisation repo list.

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,11 @@ defaults:
       type: pages
     values:
       layout: page
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: post
 
 # Files and directories to exclude from compilation
 exclude:
@@ -23,6 +28,9 @@ gems:
   - jekyll-redirect-from
   - jekyll-sitemap
   - jemoji
+
+# Post permalink format
+permalink: /news/:year/:month/:title/
 
 # Sass compilation
 sass:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,6 +15,12 @@
 					</a>
 				</li>
 
+				<li class="site-navigation__item {% if page.url contains '/news/' %}site-navigation__item--current{% endif %}" >
+					<a href="/news/" class="site-navigation__item-link">
+						News
+					</a>
+				</li>
+
 				<li class="site-navigation__item {% if page.url == '/projects/' %}site-navigation__item--current{% endif %}" >
 					<a href="/projects/" class="site-navigation__item-link">
 						Projects

--- a/_includes/post-list.html
+++ b/_includes/post-list.html
@@ -1,0 +1,9 @@
+
+<ul class="news-list">
+	{% for post in site.posts %}
+		<li class="news-list__article">
+			<strong><time datetime="{{post.date | date: '%Y-%m-%dT%H:%M:%SZ'}}">{{post.date | date: '%d %b %Y'}}</time>:</strong>
+			<a href="{{ post.url }}">{{ post.title }}</a>
+		</li>
+	{% endfor %}
+</ul>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,6 +9,7 @@
 	{% if page.sitemap == false %}<meta name="robots" content="noindex"/>{% endif %}
 
 	<!-- Site links -->
+	<link rel="alternate" type="application/atom+xml" href="/news/feed.xml" title="Pa11y News Feed"/>
 	<link rel="sitemap" type="application/xml" href="/sitemap.xml" title="Sitemap"/>
 	<link rel="canonical" href="{{site.github.url}}{{ page.url | replace: 'index.html', '' }}"/>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,11 @@
+---
+layout: page
+---
+
+<article class="news-article">
+	<header>
+		<h1 class="news-article__title">{{page.title}}</h1>
+		<p class="news-article__meta">Posted on <time datetime="{{page.date | date: '%Y-%m-%dT%H:%M:%SZ'}}">{{page.date | date: '%d %B %Y'}}</time></p>
+	</header>
+	{{content}}
+</article>

--- a/_posts/2017-09-12-pa11y-news.md
+++ b/_posts/2017-09-12-pa11y-news.md
@@ -1,0 +1,9 @@
+---
+title: Introducing Pa11y News
+description: Introducing the Pa11y news feed.
+date: 2017-09-12
+---
+
+Welcome to Pa11y News. We'll be using this feed for release announcements and communicating organisation-wide news with the community.
+
+Well that was short and sweet! Thanks for your continued use of Pa11y :tada:

--- a/_posts/2017-09-12-pa11y@5.0.0-beta.1.md
+++ b/_posts/2017-09-12-pa11y@5.0.0-beta.1.md
@@ -1,0 +1,51 @@
+---
+title: Pa11y 5.0.0 (Beta 1)
+description: Introducing the Pa11y news feed.
+date: 2017-09-12 11:00:00
+---
+
+
+Today we released the first Pa11y 5.0 beta! There are a _lot_ of changes in this release, so we'll only talk about a few – for the full list, [see the migration guide](https://github.com/pa11y/pa11y/blob/5.x/MIGRATION.md#migrating-from-40-to-50).
+
+If you just want to try out the beta, you can do so with:
+
+```sh
+npm install -g pa11y@beta
+```
+
+
+## Headless Chrome
+
+Pa11y 5.0 switches from PhantomJS to [Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome). This allows us to use more modern JavaScript APIs and make Pa11y testing more stable.
+
+
+## Node.js Support
+
+Pa11y 5.0 only supports Node.js v8.0.0 and higher, you'll need to upgrade to be able to use the latest versions of Pa11y.
+
+
+## Warnings and Notices
+
+Pa11y 5.0 ignores warnings and notices by default, as these are not usually actionable or useful in automated testing.
+
+You can force Pa11y to include warnings and notices again by using the `--include-notices` and `--include-warnings` command-line flags, or the `includeNotices` and `includeWarnings` options.
+
+
+## Promises
+
+Pa11y is now completely [`Promise`-based](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise), and uses [`async`/`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) internally. This means the API has changed significantly. This is best expressed in code:
+
+```js
+pa11y('http://example.com/').then((results) => {
+    // ...
+});
+```
+
+```js
+const results = await pa11y('http://example.com/');
+```
+
+
+## Feedback
+
+Thanks so much for your continued support, as always your feedback would be greatly appreciated. We'll keep everyone up to date via the website as new betas are released.

--- a/asset/style/_header.scss
+++ b/asset/style/_header.scss
@@ -22,7 +22,7 @@
 	display: inline-block;
 	position: relative;
 	float: left;
-	width: 25%;
+	width: 20%;
 }
 
 .site-navigation__item--has-submenu {

--- a/asset/style/site.scss
+++ b/asset/style/site.scss
@@ -141,3 +141,18 @@ $c-yellow-light: lighten($c-yellow, 35%);
 .team-list__member__role {
 	margin-bottom: 0;
 }
+
+// News list
+.news-list__article {
+	margin-bottom: $spacing-small;
+}
+
+// News article
+
+.news-article__title {
+	margin-bottom: 0;
+}
+.news-article__meta {
+	color: $c-grey;
+	font-size: $font-size-small;
+}

--- a/pages/news-feed.xml
+++ b/pages/news-feed.xml
@@ -1,0 +1,30 @@
+---
+layout:
+permalink: /news/feed.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-GB">
+
+    <title>Pa11y News Feed</title>
+    <link href="{{site.github.url}}{{page.url}}" rel="self"/>
+    <link href="{{site.github.url}}"/>
+    <updated>{{site.time | date: '%Y-%m-%dT%H:%M:%SZ'}}</updated>
+    <id>{{site.github.url}}{{page.url}}</id>
+    <author>
+        <name>Team Pa11y</name>
+    </author>
+
+    {% for post in site.posts %}
+        {% if post.sitemap != false %}
+            <entry>
+                <title>{{post.title}}</title>
+                <link href="{{site.github.url}}{{page.url | replace: 'index.html', ''}}"/>
+                <published>{{post.date | date: '%Y-%m-%dT%H:%M:%SZ'}}</published>
+                <updated>{{post.date | date: '%Y-%m-%dT%H:%M:%SZ'}}</updated>
+                <id>{{site.github.url}}{{page.url | replace: 'index.html', ''}}</id>
+                <content type="html">{{post.content | xml_escape}}</content>
+            </entry>
+        {% endif %}
+    {% endfor %}
+
+</feed>

--- a/pages/news.md
+++ b/pages/news.md
@@ -1,0 +1,12 @@
+---
+title: Pa11y News Feed
+description: News about Pa11y releases and larger project goals.
+permalink: /news/
+---
+
+
+# Pa11y News Feed
+
+News about Pa11y releases and larger project goals. Updates available via [Twitter](https://twitter.com/pa11yorg) or [Atom feed](/news/feed.xml).
+
+{% include post-list.html %}


### PR DESCRIPTION
This adds a new news page, an Atom feed for it, and posts both
introducing the news feed and outlining the Pa11y 5.0 beta.