### PR TITLE
clarify the purpose of the contact details

### DIFF
--- a/pages/contact.md
+++ b/pages/contact.md
@@ -7,17 +7,20 @@ permalink: /contact/
 
 # Contact team Pa11y
 
-You can contact any one of the core team below for any Pa11y-related issue, this could include:
+To log bugs, ask for features, or get support, please use Github issues, or join our Slack channel. 
+
+  - [Join us on Slack][pa11y-slack]
+  - [@pa11yorg on Twitter][pa11y-twitter]
+  - [@pa11y on GitHub][pa11y-github]
+
+
+If you need to contact us for another reason, for example:
 
   - If you'd like to tell us how you're using Pa11y
   - If you wish to discuss an issue before taking it public
   - If you need to report a violation of [our code of conduct][code-of-conduct]
 
-If you'd prefer not to contact an individual team member, you can contact the team here:
-
-  - [Join us on Slack][pa11y-slack]
-  - [@pa11yorg on Twitter][pa11y-twitter]
-  - [@pa11y on GitHub][pa11y-github]
+You can contact any one of the core team members listed below. Please don't log support requests with us this way! 
 
 
 ## Team members


### PR DESCRIPTION
Re-ordered these paragraphs and made it clearer that the first point of contact for bugs/support should be our public channels, not emailing core contributors directly