### PR TITLE
remove all references to Twitter

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -10,10 +10,9 @@
 # role (required):    Your role in the Pa11y team
 # avatar (optional):  An MD5 hash of your email address (see below)
 # email (optional):   An email address for Pa11y-related contact
-# twitter (optional): Your Twitter handle
 # github (optional):  Your GitHub username
 #
-# Note: while email, twitter, and github are optional, you should
+# Note: while email and github are optional, you should
 # include at least one if you want to appear on the contact page.
 #
 # Note: we use Gravatar for avatars. Gravatar requires an MD5 hash
@@ -25,40 +24,34 @@
   role: Core Contributor
   avatar: 9b617fb7c0a590faf58a516324ff53e2
   email: info@rowanmanning.com
-  twitter: rowanmanning
   github: rowanmanning
 
 - name: Hollie Kay
   role: Core Contributor
   email: hollie@hollsk.co.uk
-  twitter: _hollsk
   github: hollsk
 
 - name: Jude Robinson
   role: Core Contributor
   avatar: 0abba8c023667a16e939e2d6ada9eb5a
   email: dotcode+pa11y@gmail.com
-  twitter: j0000d
   github: dotcode
 
 - name: Glynn Phillips
   role: Core Contributor
   avatar: 18e4b23263461c7d6c078f9a19f58679
   email: info@glynnphillips.co.uk
-  twitter: glynnphillips
   github: glynnphillips
 
 - name: Andrew Mee
   role: Core Contributor
   avatar: 31514e9d3b85dd75f8e78445a1a00e4d
   email: hello@andrewmee.com
-  twitter: andrewmee
   github: andrewmee
 
 - name: Perry Harlock
   role: Core Contributor
   email: perry@phwebs.co.uk
-  twitter: perryharlock
   github: perryharlock
 
 - name: Alex Kilgour

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,12 +23,6 @@
 			</li>
 
 			<li>
-				<a href="https://twitter.com/pa11yorg">
-					Pa11y on Twitter
-				</a>
-			</li>
-
-			<li>
 				<a href="https://join.slack.com/t/pa11y/shared_invite/zt-dd7shh06-hz1I13DDJGyhgphrLxTxuw">
 					Pa11y on Slack
 				</a>

--- a/_includes/team-list.html
+++ b/_includes/team-list.html
@@ -16,14 +16,6 @@
 					</li>
 				{% endif %}
 
-				{% if team_member.twitter %}
-					<li>
-						<a href="https://twitter.com/{{team_member.twitter}}">
-							@{{team_member.twitter}} on Twitter
-						</a>
-					</li>
-				{% endif %}
-
 				{% if team_member.github %}
 					<li>
 						<a href="https://github.com/{{team_member.github}}">

--- a/contributing/communications.md
+++ b/contributing/communications.md
@@ -7,11 +7,10 @@ permalink: /contributing/communications/
 
 # Communications
 
-Hello, so you're interested in helping out with our communications? We're pretty pleased about that. This guide covers general writing style as well as everything you need to start talking to our users on [GitHub](#github) and [Twitter](#twitter). We also cover how to [respond to Code of Conduct issues](#code-of-conduct).
+Hello, so you're interested in helping out with our communications? We're pretty pleased about that. This guide covers general writing style as well as everything you need to start talking to our users. We also cover how to [respond to Code of Conduct issues](#code-of-conduct).
 
   - [Writing style](#writing-style)
   - [GitHub](#github)
-  - [Twitter](#twitter)
   - [Code of conduct](#code-of-conduct)
 
 
@@ -80,22 +79,6 @@ Sometimes we have to say no to a feature request. That's difficult. Sometimes we
 
 You should always explain _why_ you're saying no, this also gives you a point of reference if a feature request comes up again in future.
 
-
-## Twitter
-
-### Access
-
-You can get access to the [Pa11y Twitter account][pa11y-twitter] through [Tweetdeck], and currently [Rowan Manning](https://twitter.com/rowanmanning) is the right person to ask. DM him on Twitter. We don't add _everyone_ to the Twitter account, but we're pretty trusting – if you've contributed in other areas and are getting involved in the project then it'll be fine.
-
-### How/What to Tweet
-
-The Twitter account should be low-noise, mostly announcements about new projects and new versions of existing ones (we're looking into automating this). The Pa11y Twitter account should only ever retweet articles _about_ Pa11y, not feedback and messages from users.
-
-You can however respond to user questions/requests. In most cases, the appropriate action will be to point them at the correct documentation or ask them nicely to create a GitHub issue if they've found a problem.
-
-The Twitter may also be used to bring certain GitHub Issues or new web pages to the attention of a wider audience. This is useful for gathering feedback.
-
-
 ## Code of conduct
 
 Responding to [Code of Conduct][code-of-conduct] issues and violations is _really_ important. Not only do we need to do so promptly, but we need to make sure that core contributors are prepared to take necessary action.
@@ -129,11 +112,11 @@ When you've come to a decision on whether the reported behavior violates the Cod
 
   - A private reprimand to the individual(s) involved. In this case, all core team members involved in the decision should be copied in.
 
-  - A public reprimand. This should happen in the same place as the violation, e.g. Twitter, Slack, GitHub.
+  - A public reprimand. This should happen in the same place as the violation, e.g. Slack, GitHub.
 
   - An imposed vacation (i.e. asking someone to "take a week off" from a the GitHub repos, Slack, etc.). You should communicate this "vacation" to the individual(s). They'll be asked to take this vacation voluntarily, but if they don't agree then a temporary ban may be imposed to enforce this vacation.
 
-  - A permanent or temporary ban from some or all project spaces (Twitter, Slack, GitHub, etc.). You should maintain records of all such bans so that they may be reviewed in the future and extended to any new project spaces.
+  - A permanent or temporary ban from some or all project spaces (Slack, GitHub, etc.). You should maintain records of all such bans so that they may be reviewed in the future and extended to any new project spaces.
 
   - A request for a public or private apology. You may attach "strings" to this request, e.g. you may ask a violator to apologize in order to retain their membership on Slack.
 

--- a/contributing/companies.md
+++ b/contributing/companies.md
@@ -17,27 +17,26 @@ Pa11y is developed and maintained by people from many companies. We're very grat
 
 ## Active development
 
-The most direct way to contribute to Pa11y is to [write code][contributing-developers]! We're always interested in your solutions to problems or ideas for new features. Donating your developers' time to an Open Source project is a great way to show the world that you care about software quality. It's also a great way for your developers to improve their skills - not just in writing code, but also in technical communication, writing tests and documentation, and understanding different workflows. 
+The most direct way to contribute to Pa11y is to [write code][contributing-developers]! We're always interested in your solutions to problems or ideas for new features. Donating your developers' time to an Open Source project is a great way to show the world that you care about software quality. It's also a great way for your developers to improve their skills - not just in writing code, but also in technical communication, writing tests and documentation, and understanding different workflows.
 
 
 ## Providing feedback
 
-Pa11y needs to be able to meet the needs of the companies that use it. You can help us meet your organisation's needs by telling us what works and what doesn't. Although we can't make Pa11y tailored to your organisation, with your help we can make it more broadly useful to a wider range of companies, including yours. We want to hear about how you use Pa11y, and about how you'd like to use it. We use GitHub Issues to track bugs, feature requests, and discussions, so please get involved. 
+Pa11y needs to be able to meet the needs of the companies that use it. You can help us meet your organisation's needs by telling us what works and what doesn't. Although we can't make Pa11y tailored to your organisation, with your help we can make it more broadly useful to a wider range of companies, including yours. We want to hear about how you use Pa11y, and about how you'd like to use it. We use GitHub Issues to track bugs, feature requests, and discussions, so please get involved.
 
 
 ## Talking about Pa11y
 
-If you've successfully deployed Pa11y in your organisation, you can help us by telling the world about it! Tweet to us at [@pa11yorg][pa11y-twitter] to tell us about what you're doing. Consider publishing a post on your company's developer blog about how Pa11y is working for you, and what you're doing with the information it generates. Perhaps you'd like to encourage your developers to speak at conferences or internal presentations about how and why they implemented Pa11y. 
+If you've successfully deployed Pa11y in your organisation, you can help us by telling the world about it! Consider publishing a post on your company's developer blog about how Pa11y is working for you, and what you're doing with the information it generates. Perhaps you'd like to encourage your developers to speak at conferences or internal presentations about how and why they implemented Pa11y.
 
-More people hearing about Pa11y means more people participating in the project, so having organisations and representatives talk about us helps us to make our software better. 
+More people hearing about Pa11y means more people participating in the project, so having organisations and representatives talk about us helps us to make our software better.
 
 
 ## Physical space
 
-At Pa11y, we want to be transparent and plan in the open. Although our planning is publicly documented online, we also need to meet up offline to make sure we're still on track and that we have a broad consensus over the roadmap, architecture, and general policy. 
+At Pa11y, we want to be transparent and plan in the open. Although our planning is publicly documented online, we also need to meet up offline to make sure we're still on track and that we have a broad consensus over the roadmap, architecture, and general policy.
 
-Our meetings are open, so anyone can come along, and we need high-quality, accessible spaces as meeting locations. If your organisation has space that can meet our needs, please consider hosting a Pa11y meeting! 
+Our meetings are open, so anyone can come along, and we need high-quality, accessible spaces as meeting locations. If your organisation has space that can meet our needs, please consider hosting a Pa11y meeting!
 
 
-[pa11y-twitter]: https://twitter.com/pa11yorg
 [contributing-developers]: /contributing/developers/

--- a/contributing/developers.md
+++ b/contributing/developers.md
@@ -171,7 +171,7 @@ All of our projects are versioned using [Semantic Versioning] (except for this s
 
   9. **Publish**. If the project is on [npm] then you'll need to have access, and run `npm publish`.
 
-  10. **Announce**. You should announce that a new release has been made on the [Pa11y Twitter account][twitter]. Follow the style of previous tweets, but feel free to give it some personality!
+  10. **Announce**. You should announce that a new release has been made on the [Pa11y news page][news]. Follow the style of previous announcements, but feel free to give it some personality!
 
   11. **Celebrate**. :tada::beer::cake::cocktail:
 
@@ -194,4 +194,4 @@ All of our projects are versioned using [Semantic Versioning] (except for this s
 [reference-links]: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links
 [sinon]: http://sinonjs.org/
 [semantic versioning]: http://semver.org/
-[twitter]: /contributing/communications/#twitter
+[news]: https://pa11y.org/news/

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -7,10 +7,9 @@ permalink: /contact/
 
 # Contact team Pa11y
 
-To log bugs, ask for features, or get support, please use GitHub Issues, or join our Slack channel. 
+To log bugs, ask for features, or get support, please use GitHub Issues, or join our Slack channel.
 
   - [Join us on Slack][pa11y-slack]
-  - [@pa11yorg on Twitter][pa11y-twitter]
   - [@pa11y on GitHub][pa11y-github]
 
 
@@ -20,7 +19,7 @@ If you need to contact us for another reason, for example:
   - If you wish to discuss an issue before taking it public
   - If you need to report a violation of [our code of conduct][code-of-conduct]
 
-You can contact any one of the core team members listed below. Please don't log support requests with us this way! 
+You can contact any one of the core team members listed below. Please don't log support requests with us this way!
 
 
 ## Team members
@@ -40,4 +39,3 @@ members are stored in `_data/team.yml`.
 [code-of-conduct]: /contributing/code-of-conduct/
 [pa11y-github]: https://github.com/pa11y
 [pa11y-slack]: https://join.slack.com/t/pa11y/shared_invite/zt-dd7shh06-hz1I13DDJGyhgphrLxTxuw
-[pa11y-twitter]: https://twitter.com/pa11yorg

--- a/pages/news.md
+++ b/pages/news.md
@@ -7,6 +7,6 @@ permalink: /news/
 
 # Pa11y News Feed
 
-News about Pa11y releases and larger project goals. Updates available via [Twitter](https://twitter.com/pa11yorg) or [Atom feed](/news/feed.xml).
+News about Pa11y releases and larger project goals. Updates available via [Atom feed](/news/feed.xml).
 
 {% include post-list.html %}


### PR DESCRIPTION
The values of the Pa11y project and of its maintainers are dramatically out-of-sync with the corporate position of Twitter/"X", and it's time to cut ties with the latter. 

@rowanmanning Tweetdeck was disabled as part of Musk's new direction, so you're now the only one with the keys 😅 how do you feel about... just... deleting the whole Twitter account? We could always do a Mastodon later to replace it, but I don't feel like us having a presence on Twitter is really beneficial for anyone at all at this point. 