### PR TITLE
Update the link to actions help to point to github docs

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -15,7 +15,7 @@ cli:
     url: https://hackernoon.com/using-pa11y-ci-and-drone-as-accessibility-testing-gatekeepers-a8b5a3415227
 
   - title: Using actions in Pa11y
-    url: http://hollsk.co.uk/posts/view/using-actions-in-pa11y
+    url: https://github.com/pa11y/pa11y?tab=readme-ov-file#actions
 
   - title: Introduction to Accessibility Testing With Pa11y
     url: http://cruft.io/posts/accessibility-testing-with-pa11y/


### PR DESCRIPTION
Fixes broken link. 

![image](https://github.com/user-attachments/assets/2307bd65-6d6c-4a75-b6fb-c504ba2d6e8f)
